### PR TITLE
Bug Fix: Fixed lost IP address due to a dangling pointer.

### DIFF
--- a/examples/solum_qt/example/solumqt.cpp
+++ b/examples/solum_qt/example/solumqt.cpp
@@ -785,7 +785,8 @@ void Solum::onConnect()
     if (!connected_)
     {
         auto prms = solumDefaultConnectionParams();
-        prms.ipAddress = ui_->ip->text().toStdString().c_str();
+        std::string ip_str = ui_->ip->text().toStdString();
+        prms.ipAddress = ip_str.c_str();
         prms.port = ui_->port->text().toInt();
         if (solumConnect(&prms) < 0)
             ui_->status->showMessage(QStringLiteral("Connection failed"));


### PR DESCRIPTION
The original code could result in a lost IP address, causing the connection setup to fail. In C++, temporary objects have a very limited lifetime—if not stored in a named variable, they are usually destroyed at the end of the statement. This leads to invalid pointers if their internal data is accessed afterward. 

This issue was observed using MSVC2019 with Qt 6.5.3 and Qt Creator 11.0.3 (Community Edition).
